### PR TITLE
Grab href as soon as extension is loaded

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wuxinextcode/jupyterlab-notebookparams",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "A JupyterLab extension that populates notebooks with URL parameters",
   "keywords": [
     "jupyter",

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,11 +15,15 @@ const extension: JupyterFrontEndPlugin<void> = {
 };
 
 const PARAM_CELL_PARAMETERS = "# Parameters:";
+const FILTERED_PARAMS = ["reset", "clone"];
 let autorun = false;
 
 function generateParamAssignment(params: URLSearchParams, language: String): String {
   let text = "";
   for(const [key, value] of params) {
+    if (FILTERED_PARAMS.includes(key)) {
+      continue;
+    }
 
     if (key == 'autorun') {
       autorun = (value == 'true');
@@ -48,6 +52,7 @@ function generateParamAssignment(params: URLSearchParams, language: String): Str
 
 function activateExtension(app: JupyterFrontEnd, notebooks: INotebookTracker) : void {
   console.log('JupyterLab extension jupyterlab-notebookparams is activated!');
+  const href = window.location.href;
 
   notebooks.widgetAdded.connect((sender, panel: NotebookPanel) => {
 
@@ -55,7 +60,7 @@ function activateExtension(app: JupyterFrontEnd, notebooks: INotebookTracker) : 
       for(let i = 0; i < panel.model.cells.length; i++) {
         let cell = panel.model.cells.get(i);
         if(cell.value.text.startsWith(PARAM_CELL_PARAMETERS)) {
-          let searchParams = new URL(window.location.href).searchParams;
+          let searchParams = new URL(href).searchParams;
           let text = generateParamAssignment(searchParams,panel.model.defaultKernelLanguage);
           if (text) {
             cell.value.text = PARAM_CELL_PARAMETERS + '\n' + text;


### PR DESCRIPTION
Since jupyterlab >=3, url parameters are consumed before the
session context is ready which breaks the functionality of
this extension. See issue:
https://github.com/jupyterlab/jupyterlab/issues/10275

As suggested by @mokkabonna, the parameters have not been consumed
immediately after loading the extension. At that time, jupyterlab
parameters are still present.

This change moves the reading of href to the suggested point and
adds filtering of built in query parameters.

Closes #2 